### PR TITLE
Remove botbot.me log link, add alternatives

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,8 @@ Public summaries of some wizardly thinking:
 
 Useful resources:
 <ul>
-<li><a href="https://botbot.me/freenode/bitcoin-wizards/">#bitcoin-wizards logs here</a></li>
+<li><a href="http://gnusha.org/bitcoin-wizards/">#bitcoin-wizards logs here</a></li>
+<li><a href="https://freenode.irclog.whitequark.org/bitcoin-wizards/">Alternative #bitcoin-wizards logs here</a></li>
 <li><a href="http://download.wpsoftware.net/bitcoin/wizards/">Old #bitcoin-wizards logs here</a></li>
 <li><a href="http://bitcoin.sipa.be/">Sipa's hashrate statistics</a></li>
 <li><a href="https://en.bitcoin.it/wiki/User:Gmaxwell/alt_ideas">Gmaxwell's alt-ideas page</a></li>


### PR DESCRIPTION
Botbot.me has shut down

https://lincolnloop.com/blog/saying-goodbye-botbotme/